### PR TITLE
Update UpgradableFactories.lua

### DIFF
--- a/UpgradableFactories.lua
+++ b/UpgradableFactories.lua
@@ -42,7 +42,7 @@ local function getProductionPointFromPosition(pos)
 	end
 	
 	for _,prod in ipairs(g_currentMission.productionChainManager.farmIds[1].productionPoints) do
-		if MathUtil.getPointPointDistanceSquared(pos.x, pos.y, prod.owningPlaceable.position.x, prod.owningPlaceable.position.y) < 0.0001 then
+		if MathUtil.getPointPointDistanceSquared(pos.x, pos.z, prod.owningPlaceable.position.x, prod.owningPlaceable.position.z) < 0.0001 then
 			return prod
 		end
 	end
@@ -243,6 +243,7 @@ function UpgradableFactories.saveToXML()
 				local key2 = key .. ".position"
 				xmlFile:setFloat(key2 .. "#x", prodpoint.owningPlaceable.position.x)
 				xmlFile:setFloat(key2 .. "#y", prodpoint.owningPlaceable.position.y)
+				xmlFile:setFloat(key2 .. "#z", prodpoint.owningPlaceable.position.z)
 				
 				local j = 0
 				key2 = ""
@@ -289,7 +290,8 @@ function UpgradableFactories:loadXML()
 				basePrice = getXMLInt(xmlFile.handle,key .. "#basePrice"),
 				position = {
 					x = getXMLFloat(xmlFile.handle, key .. ".position#x"),
-					y = getXMLFloat(xmlFile.handle, key .. ".position#y")
+					y = getXMLFloat(xmlFile.handle, key .. ".position#y"),
+					z = getXMLFloat(xmlFile.handle, key .. ".position#z")
 				}
 			}
 		)


### PR DESCRIPTION
Fixed wrong allocating of factory position from (X;Y) to (X;Z)

Fixes mixing up productions and skipping upgrades when multiple productions have same X position, as Y equals, too on flat maps. Correct coordinates on the map are (X;Z) - Y represents the height on the map.

After fixing the code, you need to do this, to fix your savegame:

1. Disable the mod during the next loading of the savegame. 
2. Save, delete upgradableFactories.xml, save again
3. reload the game again with the mod enabled
4. Then, of course, all your upgrades are gone but after you upgraded again everything works fine in the future. Maybe you could cheat the old settings back (money cheat) or getting the fillLevels from a backup version of upgradableFactories.xml but do not copy all the messed up fillTypes of the productions resulting from the fixed bug